### PR TITLE
Please update nullability annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Bold360ai-SDK-Specs
+
+
+
+


### PR DESCRIPTION
This SDK does not build correctly when a project has nullability checks turned on and treat warnings as errors. 
Example: Download and build this repository with Xcode 11.5: https://github.com/daniel-beard/Bold360AINullabilityIssue